### PR TITLE
Some helpful warnings/error messages.

### DIFF
--- a/eso_archive.py
+++ b/eso_archive.py
@@ -27,8 +27,19 @@ if __name__ == '__main__':
 
     target = args.object
     instrument = args.instrument
+
+    if instrument is None:
+        raise ValueError("Add an instrument to query.")
+    if target is False:
+        raise ValueError("Include a target to query.")
+
     table = eso.query_instrument(instrument, column_filters={'target': target})
-    table.pprint()
+
+    if table is None:
+        print("The query 'instrument={}, target={}'. Returned no results.".format(instrument, target))
+    else:
+        table.pprint()
+
 
     # data_files = eso.retrieve_data(table['DP.ID'])
     # print data_files


### PR DESCRIPTION
So you don't try run the query for instrument=None and target=False.

And prints a helpful message if `None` is returned instead of failing when trying to `pprint` a `NoneType`